### PR TITLE
Add the implementation of StagePodAutoscaler

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -36,6 +36,7 @@ import (
 	filteredFactory "knative.dev/pkg/client/injection/kube/informers/factory/filtered"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/serving-progressive-rollout/pkg/reconciler/stagepodautoscaler"
 	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/reconciler/domainmapping"
 )
@@ -46,6 +47,7 @@ const (
 
 var ctors = []injection.ControllerConstructor{
 	configuration.NewController,
+	stagepodautoscaler.NewController,
 	labeler.NewController,
 	revision.NewController,
 	route.NewController,

--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -24,6 +24,7 @@ import (
 	sksinformer "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/serverlessservice"
 	filteredpodinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/filtered"
 	spainformer "knative.dev/serving-progressive-rollout/pkg/client/injection/informers/serving/v1/stagepodautoscaler"
+	"knative.dev/serving-progressive-rollout/pkg/reconciler/common"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	"knative.dev/serving/pkg/client/injection/ducks/autoscaling/v1alpha1/podscalable"
 	metricinformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/metric"
@@ -82,7 +83,7 @@ func NewController(
 		resync := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
 			impl.FilteredGlobalResync(onlyKPAClass, paInformer.Informer())
 		})
-		configStore := config.NewStore(logger.Named("config-store"), resync)
+		configStore := config.NewStore(logger.Named(common.ConfigStoreName), resync)
 		configStore.WatchConfigs(cmw)
 		return controller.Options{ConfigStore: configStore}
 	})

--- a/pkg/reconciler/common/constvars.go
+++ b/pkg/reconciler/common/constvars.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+const (
+	ConfigStoreName = "config-store"
+)

--- a/pkg/reconciler/stagepodautoscaler/controler.go
+++ b/pkg/reconciler/stagepodautoscaler/controler.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stagepodautoscaler
+
+import (
+	"context"
+
+	"k8s.io/client-go/tools/cache"
+
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	pkgreconciler "knative.dev/pkg/reconciler"
+	spainformer "knative.dev/serving-progressive-rollout/pkg/client/injection/informers/serving/v1/stagepodautoscaler"
+	spareconciler "knative.dev/serving-progressive-rollout/pkg/client/injection/reconciler/serving/v1/stagepodautoscaler"
+	cfgmap "knative.dev/serving/pkg/apis/config"
+	"knative.dev/serving/pkg/apis/serving"
+	servingclient "knative.dev/serving/pkg/client/injection/client"
+	painformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler"
+)
+
+// NewController creates a new StagePodAutoscaler controller
+func NewController(
+	ctx context.Context,
+	cmw configmap.Watcher,
+
+) *controller.Impl {
+	logger := logging.FromContext(ctx)
+	paInformer := painformer.Get(ctx)
+	stagePodAutoscalerInformer := spainformer.Get(ctx)
+
+	configStore := cfgmap.NewStore(logger.Named("config-store"))
+	configStore.WatchConfigs(cmw)
+
+	c := &Reconciler{
+		client:              servingclient.Get(ctx),
+		podAutoscalerLister: paInformer.Lister(),
+	}
+	opts := func(*controller.Impl) controller.Options {
+		return controller.Options{ConfigStore: configStore}
+	}
+	impl := spareconciler.NewImpl(ctx, c, opts)
+
+	stagePodAutoscalerInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	handleMatchingControllers := cache.FilteringResourceEventHandler{
+		FilterFunc: pkgreconciler.LabelExistsFilterFunc(serving.RevisionLabelKey),
+		Handler: controller.HandleAll(impl.EnqueueLabelOfNamespaceScopedResource("",
+			serving.RevisionLabelKey)),
+	}
+	paInformer.Informer().AddEventHandler(handleMatchingControllers)
+	return impl
+}

--- a/pkg/reconciler/stagepodautoscaler/stagepodautoscaler.go
+++ b/pkg/reconciler/stagepodautoscaler/stagepodautoscaler.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stagepodautoscaler
+
+import (
+	"context"
+	"fmt"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+
+	pkgreconciler "knative.dev/pkg/reconciler"
+	v1 "knative.dev/serving-progressive-rollout/pkg/apis/serving/v1"
+	spareconciler "knative.dev/serving-progressive-rollout/pkg/client/injection/reconciler/serving/v1/stagepodautoscaler"
+	clientset "knative.dev/serving/pkg/client/clientset/versioned"
+	palisters "knative.dev/serving/pkg/client/listers/autoscaling/v1alpha1"
+)
+
+// Reconciler implements controller.Reconciler for StagePodAutoscaler resources.
+type Reconciler struct {
+	client              clientset.Interface
+	podAutoscalerLister palisters.PodAutoscalerLister
+}
+
+// Check that our Reconciler implements soreconciler.Interface
+var _ spareconciler.Interface = (*Reconciler)(nil)
+
+// ReconcileKind implements Interface.ReconcileKind.
+func (c *Reconciler) ReconcileKind(ctx context.Context, spa *v1.StagePodAutoscaler) pkgreconciler.Event {
+	_, cancel := context.WithTimeout(ctx, pkgreconciler.DefaultTimeout)
+	defer cancel()
+
+	pa, err := c.podAutoscalerLister.PodAutoscalers(spa.Namespace).Get(spa.Name)
+	if apierrs.IsNotFound(err) {
+		message := fmt.Sprintf("The PodAutoscaler %v/%v was not found.", spa.Namespace, spa.Name)
+		spa.Status.MarkPodAutoscalerStageNotReady(message)
+		return nil
+	} else if err != nil {
+		spa.Status.MarkPodAutoscalerStageNotReady(err.Error())
+		return err
+	}
+
+	// As long as the PodAutoscaler with the same name as StagePodAutoscaler exists, and both of the DesiredScale
+	// the ActualScale are available, we propagate the values to StagePodAutoscaler.
+	// When these values are set in StagePodAutoscaler, it will kick off the reconciliation loop of the
+	// RolloutOrchestrator.
+	//
+	// The purpose of assigning these values to make sure the changes on PodAutoscaler can trigger the
+	// reconciliation loop of the RolloutOrchestrator.
+	if pa.Status.DesiredScale != nil && pa.Status.ActualScale != nil {
+		spa.Status.ActualScale = pa.Status.ActualScale
+		spa.Status.DesiredScale = pa.Status.DesiredScale
+		spa.Status.MarkPodAutoscalerStageReady()
+	} else {
+		message := fmt.Sprintf("The ActualScale or DesiredScale for the PodAutoscaler %v/%v was not ready.",
+			spa.Namespace, spa.Name)
+		spa.Status.MarkPodAutoscalerStageNotReady(message)
+	}
+	return nil
+}

--- a/pkg/reconciler/stagepodautoscaler/stagepodautoscaler.go
+++ b/pkg/reconciler/stagepodautoscaler/stagepodautoscaler.go
@@ -39,7 +39,7 @@ type Reconciler struct {
 var _ spareconciler.Interface = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
-func (c *Reconciler) ReconcileKind(ctx context.Context, spa *v1.StagePodAutoscaler) pkgreconciler.Event {
+func (c *Reconciler) ReconcileKind(_ context.Context, spa *v1.StagePodAutoscaler) pkgreconciler.Event {
 	pa, err := c.podAutoscalerLister.PodAutoscalers(spa.Namespace).Get(spa.Name)
 	if apierrs.IsNotFound(err) {
 		message := fmt.Sprintf("The PodAutoscaler %v/%v was not found.", spa.Namespace, spa.Name)

--- a/pkg/reconciler/stagepodautoscaler/stagepodautoscaler.go
+++ b/pkg/reconciler/stagepodautoscaler/stagepodautoscaler.go
@@ -40,9 +40,6 @@ var _ spareconciler.Interface = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
 func (c *Reconciler) ReconcileKind(ctx context.Context, spa *v1.StagePodAutoscaler) pkgreconciler.Event {
-	_, cancel := context.WithTimeout(ctx, pkgreconciler.DefaultTimeout)
-	defer cancel()
-
 	pa, err := c.podAutoscalerLister.PodAutoscalers(spa.Namespace).Get(spa.Name)
 	if apierrs.IsNotFound(err) {
 		message := fmt.Sprintf("The PodAutoscaler %v/%v was not found.", spa.Namespace, spa.Name)


### PR DESCRIPTION
## Proposed Changes
- This PR implemented the reconcile loop and added the controller for StagePodAutoscaler.
- The StagePodAutoscaler is a CR, we leverage in the autoscaler to override the PodAutoscaler. It takes precedence over PodAutoscaler. The autoscaler will first look for StagePodAutoscaler to retrieve the stageMinScale and stageMaxScale. If not found, it will look up PodAutoscaler to retrieve the minScale and maxScale.

