### PR TITLE
Updated the status before returning nil in reconcile

### DIFF
--- a/pkg/reconciler/rolloutorchestrator/rolloutorchestrator.go
+++ b/pkg/reconciler/rolloutorchestrator/rolloutorchestrator.go
@@ -84,7 +84,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ro *v1.RolloutOrchestrat
 	if rollout == nil {
 		rollout = r.rolloutStrategy[strategies.AvailabilityStrategy]
 	}
-
 	ready, err := rollout.Reconcile(ctx, ro, revScalingUp, revScalingDown, r.enqueueAfter)
 	if err != nil {
 		return err
@@ -115,8 +114,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ro *v1.RolloutOrchestrat
 		ro.Spec.TargetRevisions) {
 		// Start to move to the next stage.
 		ro.Status.LaunchNewStage()
+		return nil
 	}
 
+	ro.Status.MarkStageRevisionScaleUpReady()
+	ro.Status.MarkStageRevisionScaleDownReady()
+	ro.Status.MarkStageRevisionReady()
+	ro.Status.MarkLastStageRevisionComplete()
 	return nil
 }
 

--- a/pkg/reconciler/rolloutorchestrator/rolloutorchestrator.go
+++ b/pkg/reconciler/rolloutorchestrator/rolloutorchestrator.go
@@ -80,11 +80,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ro *v1.RolloutOrchestrat
 		return err
 	}
 
-	err = r.resetObsoleteSPAs(ctx, ro)
-	if err != nil {
-		return err
-	}
-
 	rollout := r.rolloutStrategy[strings.ToLower(ro.Spec.RolloutStrategy)]
 	if rollout == nil {
 		rollout = r.rolloutStrategy[strategies.AvailabilityStrategy]

--- a/pkg/reconciler/rolloutorchestrator/strategies/base.go
+++ b/pkg/reconciler/rolloutorchestrator/strategies/base.go
@@ -52,7 +52,7 @@ type RolloutStep interface {
 		enqueueAfter func(interface{}, time.Duration)) (bool, error)
 	// ModifyStatus function changes the status of the ro accordingly after the completion of the scaling up or down for the
 	// revisions.
-	ModifyStatus(ro *v1.RolloutOrchestrator)
+	ModifyStatus(ro *v1.RolloutOrchestrator, ready bool)
 }
 
 // The BaseScaleStep struct defines golang clients, that are necessary to access the kubernetes resources.

--- a/pkg/reconciler/rolloutorchestrator/strategies/strategy.go
+++ b/pkg/reconciler/rolloutorchestrator/strategies/strategy.go
@@ -274,7 +274,6 @@ func (s *ScaleDownStep) Verify(ctx context.Context, ro *v1.RolloutOrchestrator, 
 // ModifyStatus for ScaleDownStep modifies the status of the rolloutOrchestrator after the old revision has scaled down to
 // the expected number of pods.
 func (s *ScaleDownStep) ModifyStatus(ro *v1.RolloutOrchestrator, ready bool) {
-
 	if ready {
 		ro.Status.MarkStageRevisionScaleDownReady()
 	} else {


### PR DESCRIPTION
Fixes: #193

- This func prevents old revision going back, when the new revision fails to spin up.
- Updated the status before returning nil in the reconcile of ro.