### PR TITLE
Unify config key for stage rollout timeout option

### DIFF
--- a/pkg/reconciler/service/config.go
+++ b/pkg/reconciler/service/config.go
@@ -55,7 +55,7 @@ func NewConfigFromConfigMapFunc(configMap *corev1.ConfigMap, configMapN *corev1.
 	rolloutConfig := &RolloutConfig{
 		OverConsumptionRatio:       resources.OverSubRatio,
 		ProgressiveRolloutEnabled:  true,
-		StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeout,
+		StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeoutMinutes,
 		RolloutDuration:            "0",
 		ProgressiveRolloutStrategy: strategies.AvailabilityStrategy,
 	}
@@ -99,7 +99,7 @@ func LoadConfigFromService(annotation map[string]string, serviceAnnotation map[s
 		}
 	}
 
-	if val, ok := annotation[resources.StageRolloutTimeout]; ok {
+	if val, ok := annotation[resources.StageRolloutTimeoutMinutes]; ok {
 		timeout, err := strconv.Atoi(val)
 		if err == nil {
 			rolloutConfig.StageRolloutTimeoutMinutes = timeout

--- a/pkg/reconciler/service/config_test.go
+++ b/pkg/reconciler/service/config_test.go
@@ -38,7 +38,7 @@ func TestNewConfigFromConfigMapFunc(t *testing.T) {
 		ExpectedResult: &RolloutConfig{
 			OverConsumptionRatio:       resources.OverSubRatio,
 			ProgressiveRolloutEnabled:  true,
-			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeout,
+			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeoutMinutes,
 			RolloutDuration:            "0",
 			ProgressiveRolloutStrategy: strategies.AvailabilityStrategy,
 		},
@@ -51,7 +51,7 @@ func TestNewConfigFromConfigMapFunc(t *testing.T) {
 		ExpectedResult: &RolloutConfig{
 			OverConsumptionRatio:       resources.OverSubRatio,
 			ProgressiveRolloutEnabled:  true,
-			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeout,
+			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeoutMinutes,
 			RolloutDuration:            "0",
 			ProgressiveRolloutStrategy: strategies.AvailabilityStrategy,
 		},
@@ -145,23 +145,23 @@ func TestLoadConfigFromService(t *testing.T) {
 		configInput: &RolloutConfig{
 			OverConsumptionRatio:       resources.OverSubRatio,
 			ProgressiveRolloutEnabled:  true,
-			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeout,
+			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeoutMinutes,
 		},
 		ExpectedResult: &RolloutConfig{
 			OverConsumptionRatio:       resources.OverSubRatio,
 			ProgressiveRolloutEnabled:  true,
-			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeout,
+			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeoutMinutes,
 		},
 	}, {
 		name: "Test the RolloutConfig with valid annotation as input",
 		annotationInput: map[string]string{
-			resources.OverConsumptionRatioKey: "18",
-			resources.StageRolloutTimeout:     "10",
+			resources.OverConsumptionRatioKey:    "18",
+			resources.StageRolloutTimeoutMinutes: "10",
 		},
 		configInput: &RolloutConfig{
 			OverConsumptionRatio:       resources.OverSubRatio,
 			ProgressiveRolloutEnabled:  true,
-			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeout,
+			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeoutMinutes,
 		},
 		ExpectedResult: &RolloutConfig{
 			OverConsumptionRatio:       18,
@@ -173,13 +173,13 @@ func TestLoadConfigFromService(t *testing.T) {
 		annotationInput: map[string]string{
 			resources.OverConsumptionRatioKey:    "18",
 			resources.ProgressiveRolloutEnabled:  "false",
-			resources.StageRolloutTimeout:        "10",
+			resources.StageRolloutTimeoutMinutes: "10",
 			resources.ProgressiveRolloutStrategy: strategies.ResourceUtilStrategy,
 		},
 		configInput: &RolloutConfig{
 			OverConsumptionRatio:       resources.OverSubRatio,
 			ProgressiveRolloutEnabled:  true,
-			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeout,
+			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeoutMinutes,
 			ProgressiveRolloutStrategy: strategies.AvailabilityStrategy,
 		},
 		ExpectedResult: &RolloutConfig{
@@ -193,13 +193,13 @@ func TestLoadConfigFromService(t *testing.T) {
 		annotationInput: map[string]string{
 			resources.OverConsumptionRatioKey:    "18",
 			resources.ProgressiveRolloutEnabled:  "false",
-			resources.StageRolloutTimeout:        "10",
+			resources.StageRolloutTimeoutMinutes: "10",
 			resources.ProgressiveRolloutStrategy: strategies.AvailabilityStrategy,
 		},
 		configInput: &RolloutConfig{
 			OverConsumptionRatio:       resources.OverSubRatio,
 			ProgressiveRolloutEnabled:  true,
-			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeout,
+			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeoutMinutes,
 			ProgressiveRolloutStrategy: strategies.ResourceUtilStrategy,
 		},
 		ExpectedResult: &RolloutConfig{
@@ -213,13 +213,13 @@ func TestLoadConfigFromService(t *testing.T) {
 		annotationInput: map[string]string{
 			resources.OverConsumptionRatioKey:    "18",
 			resources.ProgressiveRolloutEnabled:  "false",
-			resources.StageRolloutTimeout:        "10",
+			resources.StageRolloutTimeoutMinutes: "10",
 			resources.ProgressiveRolloutStrategy: strategies.AvailabilityStrategy,
 		},
 		configInput: &RolloutConfig{
 			OverConsumptionRatio:       resources.OverSubRatio,
 			ProgressiveRolloutEnabled:  true,
-			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeout,
+			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeoutMinutes,
 			ProgressiveRolloutStrategy: strategies.AvailabilityStrategy,
 		},
 		ExpectedResult: &RolloutConfig{
@@ -231,13 +231,13 @@ func TestLoadConfigFromService(t *testing.T) {
 	}, {
 		name: "Test the RolloutConfig with invalid annotation as input",
 		annotationInput: map[string]string{
-			resources.OverConsumptionRatioKey: "18u",
-			resources.StageRolloutTimeout:     "8",
+			resources.OverConsumptionRatioKey:    "18u",
+			resources.StageRolloutTimeoutMinutes: "8",
 		},
 		configInput: &RolloutConfig{
 			OverConsumptionRatio:       resources.OverSubRatio,
 			ProgressiveRolloutEnabled:  true,
-			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeout,
+			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeoutMinutes,
 		},
 		ExpectedResult: &RolloutConfig{
 			OverConsumptionRatio:       resources.OverSubRatio,
@@ -247,18 +247,18 @@ func TestLoadConfigFromService(t *testing.T) {
 	}, {
 		name: "Test the RolloutConfig with invalid annotation as input",
 		annotationInput: map[string]string{
-			resources.OverConsumptionRatioKey: "18",
-			resources.StageRolloutTimeout:     "8o",
+			resources.OverConsumptionRatioKey:    "18",
+			resources.StageRolloutTimeoutMinutes: "8o",
 		},
 		configInput: &RolloutConfig{
 			OverConsumptionRatio:       resources.OverSubRatio,
 			ProgressiveRolloutEnabled:  true,
-			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeout,
+			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeoutMinutes,
 		},
 		ExpectedResult: &RolloutConfig{
 			OverConsumptionRatio:       18,
 			ProgressiveRolloutEnabled:  true,
-			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeout,
+			StageRolloutTimeoutMinutes: resources.DefaultStageRolloutTimeoutMinutes,
 		},
 	}}
 	for _, test := range tests {

--- a/pkg/reconciler/service/resources/rolloutorchestrator.go
+++ b/pkg/reconciler/service/resources/rolloutorchestrator.go
@@ -39,8 +39,8 @@ var (
 	// from the old to the new revision during each stage in the progressive rollout.
 	OverSubRatio = 10
 
-	// DefaultStageRolloutTimeout is the default timeout for stage to accomplish during the rollout.
-	DefaultStageRolloutTimeout = 2
+	// DefaultStageRolloutTimeoutMinutes is the default timeout for stage to accomplish during the rollout.
+	DefaultStageRolloutTimeoutMinutes = 2
 
 	// GroupName is the group name.
 	GroupName = "rollout.knative.dev"
@@ -48,8 +48,8 @@ var (
 	// OverConsumptionRatioKey is the annotation key Knative Service can use to specify the over consumption ratio.
 	OverConsumptionRatioKey = GroupName + "/over-consumption-ratio"
 
-	// StageRolloutTimeout is the annotation key Knative Service can use to specify the stage rollout timeout.
-	StageRolloutTimeout = GroupName + "/stage-rollout-timeout"
+	// StageRolloutTimeoutMinutes is the annotation key Knative Service can use to specify the stage rollout timeout.
+	StageRolloutTimeoutMinutes = GroupName + "/stage-rollout-timeout-minutes"
 
 	// ProgressiveRolloutEnabled is the annotation key Knative Service can use to enable or disable the progressive rollout.
 	ProgressiveRolloutEnabled = GroupName + "/progressive-rollout-enabled"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Update the ksvc annotation key for stage rollout timeout option to match the global configmap key

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind cleanup

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #225

<!-- Please include the 'why' behind your changes if no issue exists -->

There is an inconsistency in the configuration keys for the stage rollout timeout option. While the other options share the same key for both global configmap and ksvc annotation, the stage rollout timeout option has a different key for each.

**AS-IS**
- **Global configuration via configmap**: `stage-rollout-timeout-minutes`
- **Individual configuration via ksvc annotation**: `rollout.knative.dev/stage-rollout-timeout`

**TO-BE**
- **Global configuration via configmap**: `stage-rollout-timeout-minutes` (unchanged)
- **Individual configuration via ksvc annotation**: `rollout.knative.dev/stage-rollout-timeout-minutes`

This change will help prevent confusion.


**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Unify the config key for stage rollout timeout option in ksvc annotation with the global configmap key to prevent confusion.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
