### PR TITLE
Feature min scale verify

### DIFF
--- a/pkg/reconciler/service/resources/rolloutorchestrator.go
+++ b/pkg/reconciler/service/resources/rolloutorchestrator.go
@@ -197,9 +197,9 @@ func GetInitialTargetRevision(service *servingv1.Service, config *servingv1.Conf
 }
 
 // consolidateTraffic consolidates traffic with the same revision name into one.
-func consolidateTraffic(traffic []servingv1.TrafficTarget) []servingv1.TrafficTarget {
+func consolidateTraffic(trafficTargets []servingv1.TrafficTarget) []servingv1.TrafficTarget {
 	trafficMap := map[string]*servingv1.TrafficTarget{}
-	for _, traffic := range traffic {
+	for _, traffic := range trafficTargets {
 		if trafficInMap, found := trafficMap[traffic.RevisionName]; !found {
 			trafficMap[traffic.RevisionName] = traffic.DeepCopy()
 		} else {

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -956,7 +956,7 @@ func convertIntoTrafficTarget(name string, ro *v1.RolloutOrchestrator, rc *Rollo
 			if len(ro.Status.StageRevisionStatus) > 0 {
 				// If the ro has the StageRevisionStatus in the status, use it.
 				revisionTarget = ro.Status.StageRevisionStatus
-				for index := 0; index < len(revisionTarget); index++ {
+				for index := range revisionTarget {
 					if revisionTarget[index].RevisionName == spaTargetRevName {
 						continue
 					}
@@ -965,17 +965,15 @@ func convertIntoTrafficTarget(name string, ro *v1.RolloutOrchestrator, rc *Rollo
 			} else {
 				// If the ro does not have the StageRevisionStatus in the status, use the existing one in route.
 				route, errRoute := routeLister.Get(ro.Name)
-				if errRoute != nil && !apierrs.IsNotFound(errRoute) {
-					if len(route.Status.Traffic) > 0 {
-						traffics := route.Status.Traffic
-						for index := 0; index < len(traffics); index++ {
-							if traffics[index].RevisionName == spaTargetRevName {
-								continue
-							}
-							traffics[index].LatestRevision = ptr.Bool(false)
+				if errRoute == nil && len(route.Status.Traffic) > 0 {
+					traffics := route.Status.Traffic
+					for index := range traffics {
+						if traffics[index].RevisionName == spaTargetRevName || (traffics[index].LatestRevision != nil && *traffics[index].LatestRevision) {
+							continue
 						}
-						return traffics
+						traffics[index].LatestRevision = ptr.Bool(false)
 					}
+					return traffics
 				}
 			}
 		}

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -23,16 +23,17 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 	v1 "knative.dev/serving-progressive-rollout/pkg/apis/serving/v1"
+	listers "knative.dev/serving-progressive-rollout/pkg/client/listers/serving/v1"
 	"knative.dev/serving-progressive-rollout/pkg/reconciler/common"
 	"knative.dev/serving-progressive-rollout/pkg/reconciler/service/resources"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	palisters "knative.dev/serving/pkg/client/listers/autoscaling/v1alpha1"
+	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
 )
 
 func TestCreateRevRecordsFromRevList(t *testing.T) {
@@ -771,72 +772,154 @@ func TestUpdateStageTargetRevisions(t *testing.T) {
 	}
 }
 
+var (
+	MockRolloutOrchestrator = &v1.RolloutOrchestrator{
+		Spec: v1.RolloutOrchestratorSpec{
+			InitialRevisions: []v1.TargetRevision{
+				{
+					TrafficTarget: servingv1.TrafficTarget{
+						RevisionName:   "rev-001",
+						LatestRevision: ptr.Bool(false),
+						Percent:        ptr.Int64(100),
+					},
+					MinScale: ptr.Int32(10),
+					MaxScale: ptr.Int32(10),
+				},
+			},
+			TargetRevisions: []v1.TargetRevision{
+				{
+					TrafficTarget: servingv1.TrafficTarget{
+						RevisionName:   "rev-002",
+						LatestRevision: ptr.Bool(true),
+						Percent:        ptr.Int64(100),
+					},
+					MinScale: ptr.Int32(10),
+					MaxScale: ptr.Int32(10),
+				},
+			},
+			StageTarget: v1.StageTarget{
+				StageTargetRevisions: []v1.TargetRevision{
+					{
+						TrafficTarget: servingv1.TrafficTarget{
+							RevisionName:   "rev-001",
+							LatestRevision: ptr.Bool(false),
+							Percent:        ptr.Int64(80),
+						},
+						MinScale:       ptr.Int32(10),
+						MaxScale:       ptr.Int32(10),
+						TargetReplicas: ptr.Int32(8),
+						Direction:      "down",
+					},
+					{
+						TrafficTarget: servingv1.TrafficTarget{
+							RevisionName:   "rev-002",
+							LatestRevision: ptr.Bool(true),
+							Percent:        ptr.Int64(20),
+						},
+						MinScale:       ptr.Int32(10),
+						MaxScale:       ptr.Int32(10),
+						Direction:      "up",
+						TargetReplicas: ptr.Int32(2),
+					},
+				},
+			},
+		},
+		Status: v1.RolloutOrchestratorStatus{
+			RolloutOrchestratorStatusFields: v1.RolloutOrchestratorStatusFields{
+				StageRevisionStatus: []v1.TargetRevision{
+					{
+						TrafficTarget: servingv1.TrafficTarget{
+							RevisionName:   "rev-001",
+							LatestRevision: ptr.Bool(true),
+							Percent:        ptr.Int64(100),
+						},
+						MinScale:       ptr.Int32(10),
+						MaxScale:       ptr.Int32(10),
+						TargetReplicas: ptr.Int32(10),
+					},
+				},
+			},
+		},
+	}
+	MockRolloutOrchestratorNoStatus = &v1.RolloutOrchestrator{
+		Spec: v1.RolloutOrchestratorSpec{
+			InitialRevisions: []v1.TargetRevision{
+				{
+					TrafficTarget: servingv1.TrafficTarget{
+						RevisionName:   "rev-001",
+						LatestRevision: ptr.Bool(false),
+						Percent:        ptr.Int64(100),
+					},
+					MinScale: ptr.Int32(10),
+					MaxScale: ptr.Int32(10),
+				},
+			},
+			TargetRevisions: []v1.TargetRevision{
+				{
+					TrafficTarget: servingv1.TrafficTarget{
+						RevisionName:   "rev-002",
+						LatestRevision: ptr.Bool(true),
+						Percent:        ptr.Int64(100),
+					},
+					MinScale: ptr.Int32(10),
+					MaxScale: ptr.Int32(10),
+				},
+			},
+			StageTarget: v1.StageTarget{
+				StageTargetRevisions: []v1.TargetRevision{
+					{
+						TrafficTarget: servingv1.TrafficTarget{
+							RevisionName:   "rev-001",
+							LatestRevision: ptr.Bool(false),
+							Percent:        ptr.Int64(80),
+						},
+						MinScale:       ptr.Int32(10),
+						MaxScale:       ptr.Int32(10),
+						TargetReplicas: ptr.Int32(8),
+						Direction:      "down",
+					},
+					{
+						TrafficTarget: servingv1.TrafficTarget{
+							RevisionName:   "rev-002",
+							LatestRevision: ptr.Bool(true),
+							Percent:        ptr.Int64(20),
+						},
+						MinScale:       ptr.Int32(10),
+						MaxScale:       ptr.Int32(10),
+						Direction:      "up",
+						TargetReplicas: ptr.Int32(2),
+					},
+				},
+			},
+		},
+	}
+)
+
 func TestTransformService(t *testing.T) {
 	tests := []struct {
 		name            string
 		service         *servingv1.Service
 		ro              *v1.RolloutOrchestrator
+		spaLister       listers.StagePodAutoscalerNamespaceLister
+		routeLister     servinglisters.RouteNamespaceLister
+		rc              *RolloutConfig
 		ExpectedService *servingv1.Service
 	}{{
 		name: "Test with StageTargetRevisions with revision name for the latest revision",
+		spaLister: MockSPALister{
+			ActualScale: ptr.Int32(2),
+		},
+		routeLister: MockRouteLister{},
+		rc: &RolloutConfig{
+			ProgressiveRolloutEnabled: true,
+		},
 		service: &servingv1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-name",
 				Namespace: "test-ns",
 			},
 		},
-		ro: &v1.RolloutOrchestrator{
-			Spec: v1.RolloutOrchestratorSpec{
-				InitialRevisions: []v1.TargetRevision{
-					{
-						TrafficTarget: servingv1.TrafficTarget{
-							RevisionName:   "rev-001",
-							LatestRevision: ptr.Bool(false),
-							Percent:        ptr.Int64(100),
-						},
-						MinScale: ptr.Int32(10),
-						MaxScale: ptr.Int32(10),
-					},
-				},
-				TargetRevisions: []v1.TargetRevision{
-					{
-						TrafficTarget: servingv1.TrafficTarget{
-							RevisionName:   "rev-002",
-							LatestRevision: ptr.Bool(true),
-							Percent:        ptr.Int64(100),
-						},
-						MinScale: ptr.Int32(10),
-						MaxScale: ptr.Int32(10),
-					},
-				},
-				StageTarget: v1.StageTarget{
-					StageTargetRevisions: []v1.TargetRevision{
-						{
-							TrafficTarget: servingv1.TrafficTarget{
-								RevisionName:   "rev-001",
-								LatestRevision: ptr.Bool(false),
-								Percent:        ptr.Int64(60),
-							},
-							MinScale:       ptr.Int32(10),
-							MaxScale:       ptr.Int32(10),
-							TargetReplicas: ptr.Int32(6),
-							Direction:      "down",
-						},
-						{
-							TrafficTarget: servingv1.TrafficTarget{
-								RevisionName:   "rev-002",
-								LatestRevision: ptr.Bool(true),
-								Percent:        ptr.Int64(40),
-							},
-							MinScale:       ptr.Int32(10),
-							MaxScale:       ptr.Int32(10),
-							Direction:      "up",
-							TargetReplicas: ptr.Int32(4),
-						},
-					},
-				},
-			},
-		},
+		ro: MockRolloutOrchestrator,
 		ExpectedService: &servingv1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-name",
@@ -848,24 +931,140 @@ func TestTransformService(t *testing.T) {
 						{
 							RevisionName:   "rev-001",
 							LatestRevision: ptr.Bool(false),
-							Percent:        ptr.Int64(60),
+							Percent:        ptr.Int64(80),
 						},
 						{
 							ConfigurationName: "test-name",
 							LatestRevision:    ptr.Bool(true),
-							Percent:           ptr.Int64(40),
+							Percent:           ptr.Int64(20),
+						},
+					},
+				},
+			},
+		},
+	}, {
+		name: "Test with StageTargetRevisions with revision name for the latest revision, but not reaching target replicas",
+		spaLister: MockSPALister{
+			ActualScale: ptr.Int32(1),
+		},
+		routeLister: MockRouteLister{},
+		rc: &RolloutConfig{
+			ProgressiveRolloutEnabled: true,
+		},
+		service: &servingv1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-name",
+				Namespace: "test-ns",
+			},
+		},
+		ro: MockRolloutOrchestrator,
+		ExpectedService: &servingv1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-name",
+				Namespace: "test-ns",
+			},
+			Spec: servingv1.ServiceSpec{
+				RouteSpec: servingv1.RouteSpec{
+					Traffic: []servingv1.TrafficTarget{
+						{
+							RevisionName:   "rev-001",
+							LatestRevision: ptr.Bool(false),
+							Percent:        ptr.Int64(100),
+						},
+					},
+				},
+			},
+		},
+	}, {
+		name: "Test with StageTargetRevisions with revision name for the latest revision, use routeLister",
+		spaLister: MockSPALister{
+			ActualScale: ptr.Int32(1),
+		},
+		routeLister: MockRouteLister{},
+		rc: &RolloutConfig{
+			ProgressiveRolloutEnabled: true,
+		},
+		service: &servingv1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-name",
+				Namespace: "test-ns",
+			},
+		},
+		ro: MockRolloutOrchestratorNoStatus,
+		ExpectedService: &servingv1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-name",
+				Namespace: "test-ns",
+			},
+			Spec: servingv1.ServiceSpec{
+				RouteSpec: servingv1.RouteSpec{
+					Traffic: []servingv1.TrafficTarget{
+						{
+							RevisionName:   "rev-001",
+							Percent:        ptr.Int64(90),
+							LatestRevision: ptr.Bool(false),
+						},
+						{
+							ConfigurationName: "test-name",
+							Percent:           ptr.Int64(10),
+							LatestRevision:    ptr.Bool(true),
 						},
 					},
 				},
 			},
 		},
 	}}
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			service := TransformService(test.service, test.ro, nil, nil, nil)
-			if !reflect.DeepEqual(service, test.ExpectedService) {
+			service := TransformService(test.service, test.ro, test.rc, test.spaLister, test.routeLister)
+			if !reflect.DeepEqual(service.Spec.RouteSpec.Traffic, test.ExpectedService.Spec.RouteSpec.Traffic) {
 				t.Fatalf("Result of TransformService() = %v, want %v", service, test.ExpectedService)
 			}
 		})
 	}
+}
+
+type MockSPALister struct {
+	ActualScale *int32
+}
+
+func (spaLister MockSPALister) List(_ labels.Selector) (ret []*v1.StagePodAutoscaler, err error) {
+	return nil, nil
+}
+
+func (spaLister MockSPALister) Get(_ string) (*v1.StagePodAutoscaler, error) {
+	return &v1.StagePodAutoscaler{
+		Status: v1.StagePodAutoscalerStatus{
+			ActualScale: spaLister.ActualScale,
+		},
+	}, nil
+}
+
+type MockRouteLister struct {
+}
+
+func (routeLister MockRouteLister) List(_ labels.Selector) (ret []*servingv1.Route, err error) {
+	return nil, nil
+}
+
+func (routeLister MockRouteLister) Get(_ string) (*servingv1.Route, error) {
+	return &servingv1.Route{
+		Status: servingv1.RouteStatus{
+			RouteStatusFields: servingv1.RouteStatusFields{
+				Traffic: []servingv1.TrafficTarget{
+					{
+						RevisionName:   "rev-001",
+						Percent:        ptr.Int64(90),
+						LatestRevision: ptr.Bool(false),
+					},
+					{
+						ConfigurationName: "test-name",
+						Percent:           ptr.Int64(10),
+						LatestRevision:    ptr.Bool(true),
+					},
+				},
+			},
+		},
+	}, nil
 }

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -862,7 +862,7 @@ func TestTransformService(t *testing.T) {
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			service := TransformService(test.service, test.ro, nil)
+			service := TransformService(test.service, test.ro, nil, nil, nil)
 			if !reflect.DeepEqual(service, test.ExpectedService) {
 				t.Fatalf("Result of TransformService() = %v, want %v", service, test.ExpectedService)
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
